### PR TITLE
Support mulltiple PromEx processes

### DIFF
--- a/lib/prom_ex/plug.ex
+++ b/lib/prom_ex/plug.ex
@@ -2,8 +2,16 @@ defmodule PromEx.Plug do
   @moduledoc """
   Use this plug in your Endpoint file to expose your metrics. The following options are supported by this plug:
 
-  * `:prom_ex_module` - The PromEx module whose metrics will be published through this particular plug
+  * `:prom_ex_module` - The PromEx module/modules whose metrics will be published through this particular plug
   * `:path` - The path through which your metrics can be accessed (default is "/metrics")
+
+  ```elixir
+  plug PromEx.Plug, prom_ex_module: YourApp.PromEx
+  ```
+
+  ```elixir
+  plug PromEx.Plug, prom_ex_module: [YourFirstApp.PromEx, YourSecondApp.PromEx]
+  ```
 
   If you need to have some sort of access control around your metrics endpoint, I would suggest looking at another
   library that I maintain called `Unplug` (https://hex.pm/packages/unplug). Using `Unplug`, you can skip over this plug
@@ -55,27 +63,52 @@ defmodule PromEx.Plug do
   end
 
   @impl true
+  def call(%Conn{request_path: metrics_path} = conn, %{metrics_path: metrics_path, prom_ex_module: prom_ex_module})
+      when is_list(prom_ex_module) do
+    metrics =
+      Enum.reduce(prom_ex_module, "", fn module, acc ->
+        case get_metrics(module) do
+          {:ok, metrics} -> acc <> metrics
+          {:error, _} -> acc <> ""
+        end
+      end)
+
+    case metrics do
+      "" -> respond(conn, 503, "Service Unavailable")
+      metrics -> respond(conn, 200, metrics)
+    end
+  end
+
+  @impl true
   def call(%Conn{request_path: metrics_path} = conn, %{metrics_path: metrics_path, prom_ex_module: prom_ex_module}) do
-    case PromEx.get_metrics(prom_ex_module) do
-      :prom_ex_down ->
-        Logger.warn("Attempted to fetch metrics from #{prom_ex_module}, but the module has not been initialized")
-
-        conn
-        |> put_resp_content_type("text/plain")
-        |> send_resp(503, "Service Unavailable")
-        |> halt()
-
-      metrics ->
-        PromEx.ETSCronFlusher.defer_ets_flush(prom_ex_module.__ets_cron_flusher_name__())
-
-        conn
-        |> put_resp_content_type("text/plain")
-        |> send_resp(200, metrics)
-        |> halt()
+    case get_metrics(prom_ex_module) do
+      {:ok, metrics} -> respond(conn, 200, metrics)
+      {:error, error} -> respond(conn, 503, error)
     end
   end
 
   def call(conn, _opts) do
     conn
+  end
+
+  defp get_metrics(prom_ex_module) do
+    case PromEx.get_metrics(prom_ex_module) do
+      :prom_ex_down ->
+        Logger.warn("Attempted to fetch metrics from #{prom_ex_module}, but the module has not been initialized")
+
+        {:error, "Service Unavailable"}
+
+      metrics ->
+        PromEx.ETSCronFlusher.defer_ets_flush(prom_ex_module.__ets_cron_flusher_name__())
+
+        {:ok, metrics}
+    end
+  end
+
+  defp respond(conn, status, response) do
+    conn
+    |> put_resp_content_type("text/plain")
+    |> send_resp(status, response)
+    |> halt()
   end
 end

--- a/test/prom_ex/plug_test.exs
+++ b/test/prom_ex/plug_test.exs
@@ -20,6 +20,25 @@ defmodule PromEx.PlugTest do
     end
   end
 
+  defmodule AdditionalPromExSetUp do
+    use PromEx, otp_app: :prom_ex
+
+    alias PromEx.Plugins.{Application, Beam}
+
+    @impl true
+    def plugins do
+      [
+        {Application, otp_app: :prom_ex},
+        {Beam, poll_rate: 500}
+      ]
+    end
+
+    @impl true
+    def dashboards do
+      [{:prom_ex, "application.json"}]
+    end
+  end
+
   setup_all do
     System.put_env("GIT_SHA", "395459c")
     System.put_env("GIT_AUTHOR", "Alex")
@@ -64,6 +83,27 @@ defmodule PromEx.PlugTest do
              end) =~ "Attempted to fetch metrics from Elixir.PromEx.PlugTest.DefaultPromExSetUp"
     end
 
+    @tag :capture_log
+    test "should return a 503 if all metrics supervisors are not accessible" do
+      stop_supervised(DefaultPromExSetUp)
+      stop_supervised(AdditionalPromExSetUp)
+
+      opts = PromEx.Plug.init(prom_ex_module: [DefaultPromExSetUp, AdditionalPromExSetUp])
+      conn = conn(:get, "/metrics")
+      response = PromEx.Plug.call(conn, opts)
+
+      assert response.status == 503
+      assert response.resp_body == "Service Unavailable"
+
+      assert capture_log(fn ->
+               PromEx.Plug.call(conn, opts)
+             end) =~ "Attempted to fetch metrics from Elixir.PromEx.PlugTest.DefaultPromExSetUp"
+
+      assert capture_log(fn ->
+               PromEx.Plug.call(conn, opts)
+             end) =~ "Attempted to fetch metrics from Elixir.PromEx.PlugTest.AdditionalPromExSetUp"
+    end
+
     test "should return the metrics if the supervisor is running at the default path" do
       opts = PromEx.Plug.init(prom_ex_module: DefaultPromExSetUp)
       conn = conn(:get, "/metrics")
@@ -71,6 +111,19 @@ defmodule PromEx.PlugTest do
 
       assert response.status == 200
       assert response.resp_body =~ "prom_ex_application_primary_info"
+      refute response.resp_body =~ "prom_ex_beam_stats"
+      assert response.resp_body =~ "395459c"
+      assert response.resp_body =~ "Alex"
+    end
+
+    test "should return the metrics if all supervisors are running at the default path" do
+      opts = PromEx.Plug.init(prom_ex_module: [DefaultPromExSetUp, AdditionalPromExSetUp])
+      conn = conn(:get, "/metrics")
+      response = PromEx.Plug.call(conn, opts)
+
+      assert response.status == 200
+      assert response.resp_body =~ "prom_ex_application_primary_info"
+      assert response.resp_body =~ "prom_ex_beam_stats"
       assert response.resp_body =~ "395459c"
       assert response.resp_body =~ "Alex"
     end
@@ -82,6 +135,7 @@ defmodule PromEx.PlugTest do
 
       assert response.status == 200
       assert response.resp_body =~ "prom_ex_application_primary_info"
+      refute response.resp_body =~ "prom_ex_beam_stats"
       assert response.resp_body =~ "395459c"
       assert response.resp_body =~ "Alex"
     end
@@ -97,6 +151,7 @@ defmodule PromEx.PlugTest do
 
   def set_up_app_env(context) do
     Application.put_env(:prom_ex, DefaultPromExSetUp, metrics_server: :disabled)
+    Application.put_env(:prom_ex, AdditionalPromExSetUp, metrics_server: :disabled)
 
     context
   end
@@ -105,6 +160,7 @@ defmodule PromEx.PlugTest do
     # Starting PromEx module and sleeping for a short while to give the applications plugin
     # enough time to populate some metrics
     start_supervised(DefaultPromExSetUp)
+    start_supervised(AdditionalPromExSetUp)
     Process.sleep(500)
 
     context


### PR DESCRIPTION
### Change description

This change is related to prom_ex support for umbrella apps. It was initiated by this [PR](https://github.com/blockfi/blockfi-backend/pull/415) where thor is an umbrella app and there is a need to collect metrics from two apps (sources). This change allows multiple modules to be plugged into the `PromEx.Plug` module.

### What problem does this solve?

Allows you to define multiple PromEx processes and display metrics via endpoint `/metrics` collected from all sources

### Example usage

In your Endpoint module you can do:

```
plug PromEx.Plug, prom_ex_module: YourApp.PromEx
```

OR 

```
plug PromEx.Plug, prom_ex_module: [YourFirstApp.PromEx, YourSecondApp.PromEx]
```

### Checklist

- [x] I have added unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
